### PR TITLE
Correction des erreurs de build - ViewModels manquants

### DIFF
--- a/src/LogCentralPlatform.Web/ViewModels/AlertViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/AlertViewModel.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class AlertViewModel
+    {
+        public string Type { get; set; } // success, info, warning, danger
+        public string Message { get; set; }
+        public bool Dismissible { get; set; } = true;
+        public string Icon { get; set; }
+        public DateTime? Timestamp { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/ClientViewModels.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/ClientViewModels.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class ClientListViewModel
+    {
+        public List<ClientViewModel> Clients { get; set; } = new List<ClientViewModel>();
+        public int TotalCount { get; set; }
+        public int ActiveCount { get; set; }
+        public int InactiveCount { get; set; }
+    }
+
+    public class ClientViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ContactPerson { get; set; }
+        public string Email { get; set; }
+        public string Phone { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public int ServicesCount { get; set; }
+    }
+
+    public class ClientDetailsViewModel
+    {
+        public ClientViewModel Client { get; set; }
+        public List<ServiceViewModel> Services { get; set; } = new List<ServiceViewModel>();
+        public List<LogEntryViewModel> RecentLogs { get; set; } = new List<LogEntryViewModel>();
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
@@ -2,7 +2,7 @@ namespace LogCentralPlatform.Web.ViewModels
 {
     public class LoginViewModel
     {
-        public string Username { get; set; }
+        public string Email { get; set; }
         public string Password { get; set; }
         public bool RememberMe { get; set; }
         public string ReturnUrl { get; set; }

--- a/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
@@ -1,0 +1,10 @@
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class LoginViewModel
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public bool RememberMe { get; set; }
+        public string ReturnUrl { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/ServiceViewModels.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/ServiceViewModels.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class ServiceListViewModel
+    {
+        public List<ServiceViewModel> Services { get; set; } = new List<ServiceViewModel>();
+        public int TotalCount { get; set; }
+        public int ActiveCount { get; set; }
+        public int WarningCount { get; set; }
+        public int ErrorCount { get; set; }
+    }
+
+    public class ServiceViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ApiKey { get; set; }
+        public string Description { get; set; }
+        public string Version { get; set; }
+        public int ClientId { get; set; }
+        public string ClientName { get; set; }
+        public DateTime LastReportTime { get; set; }
+        public string Status { get; set; }  // Active, Warning, Error, Inactive
+        public int ReportingIntervalMinutes { get; set; }
+    }
+
+    public class ServiceDetailsViewModel
+    {
+        public ServiceViewModel Service { get; set; }
+        public List<LogEntryViewModel> RecentLogs { get; set; } = new List<LogEntryViewModel>();
+        public Dictionary<string, int> LogLevelCounts { get; set; } = new Dictionary<string, int>();
+        public List<string> AiSuggestions { get; set; } = new List<string>();
+    }
+
+    public class LogEntryViewModel
+    {
+        public int Id { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Level { get; set; }  // Info, Warning, Error, Critical
+        public string Message { get; set; }
+        public string Source { get; set; }
+        public string StackTrace { get; set; }
+        public string AdditionalData { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/SettingsViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,11 @@
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class SettingsViewModel
+    {
+        public string ApiBaseUrl { get; set; }
+        public int DefaultReportingInterval { get; set; }
+        public bool EnableAiAnalysis { get; set; }
+        public string EmailNotificationRecipients { get; set; }
+        public bool EnableEmailNotifications { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/StatCardViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/StatCardViewModel.cs
@@ -1,0 +1,14 @@
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class StatCardViewModel
+    {
+        public string Title { get; set; }
+        public string Value { get; set; }
+        public string Icon { get; set; }
+        public string Color { get; set; } // primary, success, warning, danger, info
+        public string Subtitle { get; set; }
+        public string Trend { get; set; } // up, down, stable
+        public string TrendValue { get; set; }
+        public string RedirectUrl { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/Views/_ViewImports.cshtml
+++ b/src/LogCentralPlatform.Web/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using LogCentralPlatform.Web
 @using LogCentralPlatform.Web.Models
+@using LogCentralPlatform.Web.ViewModels
 @using LogCentralPlatform.Core.Entities
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Cette pull request corrige les erreurs de build liées aux ViewModels manquants :

1. Ajout des ViewModels manquants suivants :
   - LoginViewModel
   - SettingsViewModel
   - ClientListViewModel et ClientDetailsViewModel
   - ServiceListViewModel et ServiceDetailsViewModel
   - AlertViewModel
   - StatCardViewModel

2. Mise à jour du _ViewImports.cshtml pour inclure le namespace des ViewModels

Ces modifications résoudront les erreurs CS0246 (Le nom de type ou d'espace de noms est introuvable).

Note: Pour résoudre complètement les erreurs de build, il faudra également exécuter une restauration des packages NuGet avec la commande suivante :
```
dotnet restore
```

Cela résoudra les erreurs NETSDK1004 liées aux fichiers project.assets.json manquants.