### PR TITLE
Correction des erreurs de build - ViewModels manquants

### DIFF
--- a/src/LogCentralPlatform.Web/ViewModels/ClientViewModels.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/ClientViewModels.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class ClientListViewModel
+    {
+        public List<ClientSummary> Clients { get; set; } = new List<ClientSummary>();
+        public int TotalClients { get; set; }
+        public int ActiveClients { get; set; }
+        public int InactiveClients { get; set; }
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 10;
+        public int TotalPages { get; set; }
+        public string SearchTerm { get; set; }
+    }
+
+    public class ClientSummary
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ContactEmail { get; set; }
+        public int ServiceCount { get; set; }
+        public DateTime LastActivity { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    public class ClientDetailsViewModel
+    {
+        public int Id { get; set; }
+        
+        [Required(ErrorMessage = "Le nom du client est requis")]
+        [Display(Name = "Nom du client")]
+        public string Name { get; set; }
+        
+        [Required(ErrorMessage = "L'adresse e-mail de contact est requise")]
+        [EmailAddress(ErrorMessage = "Format d'adresse e-mail invalide")]
+        [Display(Name = "E-mail de contact")]
+        public string ContactEmail { get; set; }
+        
+        [Display(Name = "Téléphone")]
+        public string Phone { get; set; }
+        
+        [Display(Name = "Adresse")]
+        public string Address { get; set; }
+        
+        [Display(Name = "Notes")]
+        public string Notes { get; set; }
+        
+        public DateTime CreatedAt { get; set; }
+        
+        public DateTime? LastModifiedAt { get; set; }
+        
+        [Display(Name = "Actif")]
+        public bool IsActive { get; set; }
+        
+        public List<ServiceSummary> Services { get; set; } = new List<ServiceSummary>();
+        
+        public List<ClientLogSummary> RecentLogs { get; set; } = new List<ClientLogSummary>();
+    }
+
+    public class ClientLogSummary
+    {
+        public int Id { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string ServiceName { get; set; }
+        public string Level { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/LoginViewModel.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class LoginViewModel
+    {
+        [Required(ErrorMessage = "Le nom d'utilisateur est requis")]
+        [Display(Name = "Nom d'utilisateur")]
+        public string Username { get; set; }
+
+        [Required(ErrorMessage = "Le mot de passe est requis")]
+        [DataType(DataType.Password)]
+        [Display(Name = "Mot de passe")]
+        public string Password { get; set; }
+
+        [Display(Name = "Se souvenir de moi")]
+        public bool RememberMe { get; set; }
+
+        public string ReturnUrl { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/ServiceViewModels.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/ServiceViewModels.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class ServiceListViewModel
+    {
+        public List<ServiceSummary> Services { get; set; } = new List<ServiceSummary>();
+        public int TotalServices { get; set; }
+        public int OnlineServices { get; set; }
+        public int OfflineServices { get; set; }
+        public int WarningServices { get; set; }
+        public int Page { get; set; } = 1;
+        public int PageSize { get; set; } = 10;
+        public int TotalPages { get; set; }
+        public string SearchTerm { get; set; }
+        public string ClientFilter { get; set; }
+        public string StatusFilter { get; set; }
+    }
+
+    public class ServiceSummary
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public string ClientName { get; set; }
+        public int ClientId { get; set; }
+        public DateTime LastHeartbeat { get; set; }
+        public string Status { get; set; }
+        public int ErrorCount24h { get; set; }
+        public string ApiKey { get; set; }
+    }
+
+    public class ServiceDetailsViewModel
+    {
+        public int Id { get; set; }
+        
+        [Required(ErrorMessage = "Le nom du service est requis")]
+        [Display(Name = "Nom du service")]
+        public string Name { get; set; }
+        
+        [Display(Name = "Description")]
+        public string Description { get; set; }
+        
+        [Display(Name = "Version")]
+        public string Version { get; set; }
+        
+        [Required(ErrorMessage = "L'ID du client est requis")]
+        public int ClientId { get; set; }
+        
+        [Display(Name = "Client")]
+        public string ClientName { get; set; }
+        
+        [Display(Name = "Intervalle de reporting (minutes)")]
+        [Range(1, 1440, ErrorMessage = "L'intervalle doit être compris entre 1 et 1440 minutes")]
+        public int ReportingInterval { get; set; }
+        
+        [Display(Name = "URL de callback")]
+        public string CallbackUrl { get; set; }
+        
+        [Display(Name = "Clé API")]
+        public string ApiKey { get; set; }
+        
+        public DateTime LastHeartbeat { get; set; }
+        
+        [Display(Name = "État")]
+        public string Status { get; set; }
+        
+        public DateTime CreatedAt { get; set; }
+        
+        public List<LogEntrySummary> RecentLogs { get; set; } = new List<LogEntrySummary>();
+        
+        public ServiceStatsViewModel Stats { get; set; } = new ServiceStatsViewModel();
+    }
+
+    public class LogEntrySummary
+    {
+        public int Id { get; set; }
+        public DateTime Timestamp { get; set; }
+        public string Level { get; set; }
+        public string Message { get; set; }
+        public string Context { get; set; }
+    }
+
+    public class ServiceStatsViewModel
+    {
+        public int TotalLogsCount { get; set; }
+        public int ErrorsLast24h { get; set; }
+        public int WarningsLast24h { get; set; }
+        public int InfoLast24h { get; set; }
+        public double UptimePercentage { get; set; }
+        public DateTime? LastErrorTime { get; set; }
+        public TimeSpan AverageResponseTime { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/SettingsViewModel.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class SettingsViewModel
+    {
+        [Required(ErrorMessage = "L'URL de base de l'API est requise")]
+        [Display(Name = "URL de base de l'API")]
+        public string ApiBaseUrl { get; set; }
+
+        [Required(ErrorMessage = "L'intervalle de rapport par défaut est requis")]
+        [Range(1, 1440, ErrorMessage = "L'intervalle doit être compris entre 1 et 1440 minutes")]
+        [Display(Name = "Intervalle de rapport par défaut (minutes)")]
+        public int DefaultReportingInterval { get; set; }
+
+        [Display(Name = "Activer l'analyse IA")]
+        public bool EnableAiAnalysis { get; set; }
+
+        [Display(Name = "Destinataires des notifications par e-mail")]
+        public string EmailNotificationRecipients { get; set; }
+
+        [Display(Name = "Activer les notifications par e-mail")]
+        public bool EnableEmailNotifications { get; set; }
+
+        [Display(Name = "Niveau de log minimum pour les notifications")]
+        public string MinimumLogLevelForNotifications { get; set; }
+
+        [Display(Name = "Délai d'expiration de session (minutes)")]
+        [Range(1, 1440, ErrorMessage = "Le délai doit être compris entre 1 et 1440 minutes")]
+        public int SessionTimeoutMinutes { get; set; }
+    }
+}

--- a/src/LogCentralPlatform.Web/ViewModels/SharedViewModels.cs
+++ b/src/LogCentralPlatform.Web/ViewModels/SharedViewModels.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace LogCentralPlatform.Web.ViewModels
+{
+    public class AlertViewModel
+    {
+        public string Type { get; set; } // success, warning, danger, info
+        public string Message { get; set; }
+        public bool Dismissible { get; set; } = true;
+        public int DisplayDuration { get; set; } = 5000; // milliseconds, 0 for no auto-dismiss
+    }
+
+    public class StatCardViewModel
+    {
+        public string Title { get; set; }
+        public string Value { get; set; }
+        public string Icon { get; set; }
+        public string Color { get; set; } // primary, success, warning, danger, info
+        public string Trend { get; set; } // up, down, stable
+        public string TrendValue { get; set; }
+        public string Link { get; set; }
+    }
+
+    public class PaginationViewModel
+    {
+        public int CurrentPage { get; set; }
+        public int TotalPages { get; set; }
+        public string RouteAction { get; set; }
+        public Dictionary<string, string> RouteParams { get; set; } = new Dictionary<string, string>();
+    }
+
+    public class DashboardViewModel
+    {
+        public List<StatCardViewModel> Stats { get; set; } = new List<StatCardViewModel>();
+        public List<AlertViewModel> Alerts { get; set; } = new List<AlertViewModel>();
+        public List<ServiceSummary> RecentlyOfflineServices { get; set; } = new List<ServiceSummary>();
+        public List<LogEntrySummary> RecentErrors { get; set; } = new List<LogEntrySummary>();
+        public Dictionary<string, int> LogLevelDistribution { get; set; } = new Dictionary<string, int>();
+        public Dictionary<DateTime, int> LogsTimeline { get; set; } = new Dictionary<DateTime, int>();
+    }
+}


### PR DESCRIPTION
## Description
Cette pull request corrige les erreurs de build liées aux modèles de vue (ViewModels) manquants dans le projet LogCentralPlatform.Web.

## Corrections apportées
- Création des ViewModels référencés dans les vues Razor :
  - `LoginViewModel` pour la page de connexion
  - `SettingsViewModel` pour la page des paramètres
  - `ClientListViewModel` et `ClientDetailsViewModel` pour les vues des clients
  - `ServiceListViewModel` et `ServiceDetailsViewModel` pour les vues des services
  - `AlertViewModel` et `StatCardViewModel` pour les composants partagés

## Prochaines étapes
1. Exécuter `dotnet restore` pour résoudre les erreurs NETSDK1004 liées aux fichiers project.assets.json manquants.
2. Confirmer que le projet compile correctement après ces modifications.

## Documentation
Ces modifications s'alignent avec la structure de projet décrite dans la documentation et respectent les conventions de nommage établies.
